### PR TITLE
Installation guide in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,5 +71,6 @@ Or specify the individual items you need.
 ```ts
 import { PlayerAnim, shapeGenerator } from "https://deno.land/x/mapkey/src/exports.ts"
 ```
-**Important**
+**Important!**
+
 When you add your import it will likely show an error, make sure you update the version to its redirected specifier, and that you cache all dependencies.

--- a/README.md
+++ b/README.md
@@ -60,3 +60,15 @@ des.exclude([
 ])
 ```
 these 2 choices will apply to almost all of the functions here, for any that it doesn't I'll say that in the documentation for the function
+# Installation
+To use Map Key in your script, you will need to import it. This works in the same way as ReMapper.
+
+You can either import all items.
+```ts
+import * as mk from "https://deno.land/x/mapkey@0.0.3/src/exports.ts"
+```
+Or specify the individual items you need.
+```ts
+import { PlayerAnim, shapeGenerator } from "https://deno.land/x/mapkey@0.0.3/src/exports.ts"
+```
+Just make sure that your version tag is set to the latest release to make sure that the code remains compatible with ReMapper.

--- a/README.md
+++ b/README.md
@@ -65,10 +65,11 @@ To use Map Key in your script, you will need to import it. This works in the sam
 
 You can either import all items.
 ```ts
-import * as mk from "https://deno.land/x/mapkey@0.0.3/src/exports.ts"
+import * as mk from "https://deno.land/x/mapkey/src/exports.ts"
 ```
 Or specify the individual items you need.
 ```ts
-import { PlayerAnim, shapeGenerator } from "https://deno.land/x/mapkey@0.0.3/src/exports.ts"
+import { PlayerAnim, shapeGenerator } from "https://deno.land/x/mapkey/src/exports.ts"
 ```
-Just make sure that your version tag is set to the latest release to make sure that the code remains compatible with ReMapper.
+**Important**
+When you add your import it will likely show an error, make sure you update the version to its redirected specifier, and that you cache all dependencies.

--- a/src/utils/general.ts
+++ b/src/utils/general.ts
@@ -17,7 +17,7 @@ export function rgb(value: ColorType) {
   return [val1, val2, val3, value[3]] as ColorType
 }
 
-import { notesBetween, arcsBetween, chainsBetween, wallsBetween} from "https://deno.land/x/remapper@3.0.0/src/mod.ts"
+import { notesBetween, arcsBetween, chainsBetween} from "https://deno.land/x/remapper@3.0.0/src/mod.ts"
 import { BFM_PROPS } from "../constants.ts";
 
 export function allBetween(time: number, timeEnd: number, forAll: (n: Note) => void) {


### PR DESCRIPTION
Even though it is included in the wiki, including it in README.md allows users to view the installation on the main page. As they may not initially think to look in the wiki.

Also removed an unused import in general.ts after the removal of walls in `allBetween().`