### PR TITLE
Update to geometry filter + new Environment filter

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -41,6 +41,43 @@ export type ENV_FILTER_PROPS =
     "id" |
     "lookupMethod"
 
+// I have no clue what I'm doing here - Aurellis
+// export enum GEO_FILTER_PROPS_ENUM {
+//     Track = "track",
+//     Position = "position",
+//     Position X = "position[0]",
+//     Position Y = "position[1]",
+//     Position Z = "position[2]",
+//     Rotation = "rotation",
+//     Rotation X = "rotation[0]",
+//     Rotation Y = "rotation[1]",
+//     Rotation Z = "rotation[2]",
+//     Scale = "scale",
+//     Scale X = "scale[0]",
+//     Scale Y = "scale[1]",
+//     Scale Z = "scale[2]",
+//     GeoType = "type",
+//     Material = "material"
+// }
+
+// export enum ENV_FILTER_PROPS_ENUM {
+//     Track = "track",
+//     Position = "position",
+//     Position X = "position[0]",
+//     Position Y = "position[1]",
+//     Position Z = "position[2]",
+//     Rotation = "rotation",
+//     Rotation X = "rotation[0]",
+//     Rotation Y = "rotation[1]",
+//     Rotation Z = "rotation[2]",
+//     Scale = "scale",
+//     Scale X = "scale[0]",
+//     Scale Y = "scale[1]",
+//     Scale Z = "scale[2]",
+//     ID = "id",
+//     LookupMethod = "lookupMethod"
+// }
+
 export const Env = {
     gaga: {
         Aurora: "AuroraSecondary$",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,7 +7,7 @@ export type BFM_PROPS =
     "_totalFrames" |
     "_framesPerBeat"
     
-export type GEO_FILTER_PROPS = 
+    export type GEO_FILTER_PROPS = 
     "track" |
     "position" |
     "position[0]" |
@@ -20,7 +20,9 @@ export type GEO_FILTER_PROPS =
     "scale" |
     "scale[0]" |
     "scale[1]" |
-    "scale[2]"
+    "scale[2]" |
+    "type" |
+    "material"
 
 export type ENV_FILTER_PROPS = 
     "track" |

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -83,7 +83,8 @@ export const Env = {
         Aurora: "AuroraSecondary$",
         Lightning: "1L\\.\\[\\d+\\]\\w+\\.\\[\\d+\\]LightningWithTarget$",
         solidLaser: "FrontLaserL$",
-        directionalLight: "DirectionalLightFront$"
+        directionalLight: "DirectionalLightFront$",
+        gagaLogo: "[^Logo]{4}\\.\\[\\d+\\]Logo$",
     },
     billie: {
         directionalLight: "Day\\.\\[\\d+\\]\\w+Front$",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -43,20 +43,20 @@ export type ENV_FILTER_PROPS =
 
 export const Env = {
     gaga: {
-        Aurora: "Aurora\\.\\[1\\]AuroraSecondary$",
-        Lightning: "[3\\]LightingWithTarget$",
-        solidLaser: "[0\\]FrontLaserL$",
-        directionalLight: "DirectionalLights\\.\\[0\\]DirectionalLightFront$"
+        Aurora: "AuroraSecondary$",
+        Lightning: "1L\\.\\[\\d+\\]\\w+\\.\\[\\d+\\]LightningWithTarget$",
+        solidLaser: "FrontLaserL$",
+        directionalLight: "DirectionalLightFront$"
     },
     billie: {
-        directionalLight: "DayAndNight\\.\\[0\\]Day\\.\\[1\\]DirectionalLightFront$",
-        solidLaser: "[46\\]BottomPairLasers\\.\\[0\\]PillarL\\.\\[0\\]RotationBaseL\\.\\[0\\]LaserLH"
+        directionalLight: "Day\\.\\[\\d+\\]\\w+Front$",
+        solidLaser: "\\w+\\.\\[\\d+\\]\\w+L\\.\\[\\d+\\]\\w+L\\.\\[\\d+\\]\\w+LH"
     },
 
     all: {
         cinemaScreen: "CinemaScreen$",
         cinemaDirLight: "CinemaDirectionalLight$",
-        mirror: "PlayersPlace\\.\\[d*\\]Mirror"
+        mirror: "Place\\.\\[\\d+\\]Mirror$"
     }
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,6 +7,21 @@ export type BFM_PROPS =
     "_totalFrames" |
     "_framesPerBeat"
     
+export type GEO_FILTER_PROPERTIES = 
+    "track" |
+    "position" |
+    "position[0]" |
+    "position[1]" |
+    "position[2]" |
+    "rotation" |
+    "rotation[0]" |
+    "rotation[1]" |
+    "rotation[2]" |
+    "scale" |
+    "scale[0]" |
+    "scale[1]" |
+    "scale[2]"
+
 export const Env = {
     gaga: {
         Aurora: "Aurora\\.\\[1\\]AuroraSecondary$",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,7 +7,7 @@ export type BFM_PROPS =
     "_totalFrames" |
     "_framesPerBeat"
     
-export type GEO_FILTER_PROPERTIES = 
+export type GEO_FILTER_PROPS = 
     "track" |
     "position" |
     "position[0]" |
@@ -21,6 +21,23 @@ export type GEO_FILTER_PROPERTIES =
     "scale[0]" |
     "scale[1]" |
     "scale[2]"
+
+export type ENV_FILTER_PROPS = 
+    "track" |
+    "position" |
+    "position[0]" |
+    "position[1]" |
+    "position[2]" |
+    "rotation" |
+    "rotation[0]" |
+    "rotation[1]" |
+    "rotation[2]" |
+    "scale" |
+    "scale[0]" |
+    "scale[1]" |
+    "scale[2]" |
+    "id" |
+    "lookupMethod"
 
 export const Env = {
     gaga: {

--- a/src/utils/general.ts
+++ b/src/utils/general.ts
@@ -29,7 +29,7 @@ export function rgb(value: ColorType, colorMultiplier?: number) {
 }
 
 import { notesBetween, arcsBetween, chainsBetween} from "https://deno.land/x/remapper@3.0.0/src/mod.ts"
-import { BFM_PROPS } from "../constants.ts";
+import { BFM_PROPS, GEO_FILTER_PROPERTIES } from "../constants.ts";
 
 export function allBetween(time: number, timeEnd: number, forAll: (n: Note) => void) {
   notesBetween(time, timeEnd, forAll)
@@ -39,15 +39,27 @@ export function allBetween(time: number, timeEnd: number, forAll: (n: Note) => v
 
 /**
  * Works like notesBetween. Except it searches for geometry, with track as a filter rather than time.
- * @param track The track of the geometry you wish to target.
- * @param forEach Executed for every geometry piece.
+ * @param property The property of the geometry you wish to target
+ * @param value The value of that property to pass.
+ * @param forEach Executed for every passed geometry piece.
  */
-export function filterGeometry(track: Track, forEach: (x: Geometry) => void){
-  activeDiffGet().geometry((arr: any[]) =>{
-    arr.forEach(x =>{
-      if (x.track.has("track")) {forEach(x)}
-    });
-  });
+export function filterGeometry(property: GEO_FILTER_PROPERTIES, value: number[] | string | number, forEach: (x: Geometry) => void){
+  activeDiffGet().geometry((arr: Geometry[]) =>{
+    if(property === "track"){
+      arr.forEach(x =>{
+        if (x.track.has(value.toString())){
+            forEach(x);
+        }
+      })
+    }
+    else {
+      arr.forEach((x) =>{
+        if(eval(`x.${property}.toString()`) == value.toString()){
+            forEach(x);
+        }
+      })
+    }
+  })
 }
 
 export class blenderFrameMath {

--- a/src/utils/general.ts
+++ b/src/utils/general.ts
@@ -1,5 +1,5 @@
 import { ensureDir } from "https://deno.land/std@0.110.0/fs/ensure_dir.ts";
-import { ColorType, DIFFS, FILENAME, info, Note, RMLog, Geometry, Track, activeDiffGet } from "https://deno.land/x/remapper@3.0.0/src/mod.ts"
+import { ColorType, DIFFS, FILENAME, info, Note, RMLog, Environment, Geometry, activeDiffGet } from "https://deno.land/x/remapper@3.0.0/src/mod.ts"
 
 export function logFunctions() {
   export const logFunctionss = true
@@ -29,7 +29,7 @@ export function rgb(value: ColorType, colorMultiplier?: number) {
 }
 
 import { notesBetween, arcsBetween, chainsBetween} from "https://deno.land/x/remapper@3.0.0/src/mod.ts"
-import { BFM_PROPS, GEO_FILTER_PROPERTIES } from "../constants.ts";
+import { BFM_PROPS, GEO_FILTER_PROPS, ENV_FILTER_PROPS } from "../constants.ts";
 
 export function allBetween(time: number, timeEnd: number, forAll: (n: Note) => void) {
   notesBetween(time, timeEnd, forAll)
@@ -43,8 +43,26 @@ export function allBetween(time: number, timeEnd: number, forAll: (n: Note) => v
  * @param value The value of that property to pass.
  * @param forEach Executed for every passed geometry piece.
  */
-export function filterGeometry(property: GEO_FILTER_PROPERTIES, value: number[] | string | number, forEach: (x: Geometry) => void){
+export function filterGeometry(property: GEO_FILTER_PROPS, value: number[] | string | number, forEach: (x: Geometry) => void){
   activeDiffGet().geometry((arr: Geometry[]) =>{
+    if(property === "track"){
+      arr.forEach(x =>{
+        if (x.track.has(value.toString())){
+            forEach(x);
+        }
+      })
+    }
+    else {
+      arr.forEach((x) =>{
+        if(eval(`x.${property}.toString()`) == value.toString()){
+            forEach(x);
+        }
+      })
+    }
+  })
+}
+export function filterEnvironments(property: ENV_FILTER_PROPS, value: number[] | string | number, forEach: (x: Environment) => void){
+  activeDiffGet().environment((arr: Environment[]) =>{
     if(property === "track"){
       arr.forEach(x =>{
         if (x.track.has(value.toString())){

--- a/src/utils/general.ts
+++ b/src/utils/general.ts
@@ -38,7 +38,7 @@ export function allBetween(time: number, timeEnd: number, forAll: (n: Note) => v
 }
 
 /**
- * Works like notesBetween. Except it searches for environments, with a set value for any property on the object as the filter.
+ * Works like notesBetween. Except it searches for geometry, with a set value for any property on the object as the filter.
  * @param property The property to check for on each geometry object.
  * @param value The value that the property must be to pass.
  * @param forEach What to execute for each object that passes.

--- a/src/utils/general.ts
+++ b/src/utils/general.ts
@@ -42,6 +42,8 @@ export function allBetween(time: number, timeEnd: number, forAll: (n: Note) => v
  * @param property The property to check for on each geometry object.
  * @param value The value that the property must be to pass.
  * @param forEach What to execute for each object that passes.
+ * @author Aurellis
+ * @todo Enum property for easier use.
  */
 export function filterGeometry(property: GEO_FILTER_PROPS, value: number[] | string | number, forEach: (x: Geometry) => void){
   activeDiffGet().geometry((arr: Geometry[]) =>{
@@ -67,6 +69,8 @@ export function filterGeometry(property: GEO_FILTER_PROPS, value: number[] | str
  * @param property The property to check for on each environment object.
  * @param value The value that the property must be to pass.
  * @param forEach What to execute for each object that passes.
+ * @author Aurellis
+ * @todo Enum property for easier use.
  */
 export function filterEnvironments(property: ENV_FILTER_PROPS, value: number[] | string | number, forEach: (x: Environment) => void){
   activeDiffGet().environment((arr: Environment[]) =>{

--- a/src/utils/general.ts
+++ b/src/utils/general.ts
@@ -38,10 +38,10 @@ export function allBetween(time: number, timeEnd: number, forAll: (n: Note) => v
 }
 
 /**
- * Works like notesBetween. Except it searches for geometry, with track as a filter rather than time.
- * @param property The property of the geometry you wish to target
- * @param value The value of that property to pass.
- * @param forEach Executed for every passed geometry piece.
+ * Works like notesBetween. Except it searches for environments, with a set value for any property on the object as the filter.
+ * @param property The property to check for on each geometry object.
+ * @param value The value that the property must be to pass.
+ * @param forEach What to execute for each object that passes.
  */
 export function filterGeometry(property: GEO_FILTER_PROPS, value: number[] | string | number, forEach: (x: Geometry) => void){
   activeDiffGet().geometry((arr: Geometry[]) =>{
@@ -61,6 +61,13 @@ export function filterGeometry(property: GEO_FILTER_PROPS, value: number[] | str
     }
   })
 }
+
+/**
+ * Works like notesBetween. Except it searches for environments, with a set value for any property on the object as the filter.
+ * @param property The property to check for on each environment object.
+ * @param value The value that the property must be to pass.
+ * @param forEach What to execute for each object that passes.
+ */
 export function filterEnvironments(property: ENV_FILTER_PROPS, value: number[] | string | number, forEach: (x: Environment) => void){
   activeDiffGet().environment((arr: Environment[]) =>{
     if(property === "track"){


### PR DESCRIPTION
Geometry filter can now filter by multiple properties (DM me if I missed any properties that Geo can have)
Environment filter - works the same as the geo filter, but affects environments, it also has the "id" and "lookupMethod" properties to use as filters. (again, DM me if I missed any)
I don't really know what the environment filter could be used for unless you want to target specific envs made by modelScene or something.